### PR TITLE
Added versions of terms

### DIFF
--- a/latest/common/terms.html
+++ b/latest/common/terms.html
@@ -6,14 +6,14 @@ the reader:
 </p>
 
 <dl class="termlist">
-  <dt><dfn>account</dfn></dt>
+  <dt><dfn lt="account|accounts">account</dfn></dt>
 
   <dd>[PSD2] an account held in the name of one or more payment service
   users which is used for the execution of payment transactions.
   [Capabilities] An account is a store of value with a balance and a
   history of debits and credits that affect that balance</dd>
 
-  <dt><dfn>account provider</dfn></dt>
+  <dt><dfn lt="account provider|account providers">account provider</dfn></dt>
 
   <dd>[PSD2] account servicing payment service provider: a payment
   service provider providing and maintaining the payment account from
@@ -46,19 +46,19 @@ the reader:
   the netting of orders and the establishment of final positions for
   settlement</dd>
 
-  <dt><dfn>credit institution</dfn></dt>
+  <dt><dfn lt="credit institution|credit institutions">credit institution</dfn></dt>
 
   <dd>[ECB] a company duly authorized to carry out banking transactions
   on a regular basis (i.e. to receive deposits from the public, carry
   out credit transactions, make funds available and manage means of
   payment)</dd>
 
-  <dt><dfn>customer</dfn></dt>
+  <dt><dfn lt="customer|customers">customer</dfn></dt>
 
   <dd>An entity paying to receive goods, services, or other things of
   value; abstractly known as a payer.</dd>
 
-  <dt><dfn>electronic money institution</dfn></dt>
+  <dt><dfn lt="electronic money institution|electronic money institutions">electronic money institution</dfn></dt>
 
   <dd>[ECB] a term used in EU legislation to designate credit
   institutions which are governed by a simplified regulatory regime
@@ -66,7 +66,7 @@ the reader:
   and the provision of financial and non-financial services closely
   related to the issuance of electronic money.</dd>
 
-  <dt><dfn>entity</dfn></dt>
+  <dt><dfn lt="entity|entities">entity</dfn></dt>
 
   <dd>A person, organization, or software agent that is capable of
   interacting with the world.</dd>
@@ -81,39 +81,39 @@ the reader:
   limitations as to who may join the scheme, as long as the requirements
   of the scheme are met.</dd>
 
-  <dt><dfn>identity</dfn></dt>
+  <dt><dfn lt="identity|identities">identity</dfn></dt>
 
   <dd>A set of information that can be used to identify a particular
   entity such as a person, software agent, or organization. An entity
   may have multiple identities associated with it.</dd>
 
-  <dt><dfn>ledger</dfn></dt>
+  <dt><dfn lt="ledger|ledgers">ledger</dfn></dt>
 
   <dd>[Merriam-Webster] a book containing accounts to which debits and
   credits are posted from books of original entry</dd>
 
-  <dt><dfn>merchant</dfn></dt>
+  <dt><dfn lt="merchant|merchants">merchant</dfn></dt>
 
   <dd>An entity receiving payment for goods, services, or other things
   of value; abstractly known as a payee.</dd>
 
-  <dt><dfn>payee</dfn></dt>
+  <dt><dfn lt="payee|payees">payee</dfn></dt>
 
   <dd>An entity that receives funds as required by a transaction.</dd>
 
-  <dt><dfn>payer</dfn></dt>
+  <dt><dfn lt="payer|payers">payer</dfn></dt>
 
   <dd>An entity that provides a source of funds as required by a
   transaction.</dd>
 
-  <dt><dfn>payment</dfn></dt>
+  <dt><dfn lt="payment|payments">payment</dfn></dt>
 
   <dd>[ECB] in a strict sense, a payment is a transfer of funds which
   discharges an obligation on the part of a payer vis-a-vis a payee.
   However, in a technical or statistical sense, it is often used as a
   synonym for <a>transfer order</a></dd>
 
-  <dt><dfn>payment instrument</dfn></dt>
+  <dt><dfn lt="payment instrument|payment instruments">payment instrument</dfn></dt>
 
   <dd>A mechanism used to transfer value from a <a>payer</a> to a
   <a>payee</a>. Examples: Corporate Visa card, personal Visa card, a
@@ -123,24 +123,24 @@ the reader:
   order to initiate a payment order. [ECB] a tool or a set of procedures
   enabling the transfer of funds from a payer to a payee.</dd>
 
-  <dt><dfn>payment orchestrator</dfn></dt>
+  <dt><dfn lt="payment orchestrator|payment orchestrators">payment orchestrator</dfn></dt>
 
   <dd>The payment orchestrator is the entity or entities (payer, payee
   or payment service provider) that are orchestrating the steps required
   to complete the payment flow.</dd>
 
-  <dt><dfn>payment order</dfn></dt>
+  <dt><dfn lt="payment order|payment orders">payment order</dfn></dt>
 
   <dd>[PSD2] any instruction by a payer or payee to his payment service
   provider requesting the execution of a payment transaction</dd>
 
-  <dt><dfn>payment processor</dfn></dt>
+  <dt><dfn lt="payment processor|payment processors">payment processor</dfn></dt>
 
   <dd>An <a>entity</a> that submits and processes payments using a
   particular <a>payment instrument</a> to a payment network. Examples:
   Stripe, PayPal, Authorize.net, Atos, FedACH.</dd>
 
-  <dt><dfn>payment scheme</dfn></dt>
+  <dt><dfn lt="payment scheme|payment schemes">payment scheme</dfn></dt>
 
   <dd>Sets of rules and technical standards for the execution of payment
   <a title="transaction">transactions</a> that have to be followed by
@@ -151,7 +151,7 @@ the reader:
   interbank rules, practices and standards necessary for the functioning
   of payment services.</dd>
 
-  <dt><dfn>payment service provider</dfn></dt>
+  <dt><dfn lt="payment service provider|payment service providers">payment service provider</dfn></dt>
 
   <dd>
     [PSD] A body executing payment services such as
@@ -174,25 +174,25 @@ the reader:
     </ol>
   </dd>
 
-  <dt><dfn>pull payment</dfn> or <dfn>payee-initiated payment</dfn></dt>
+  <dt><dfn lt="pull payment|pull payments">pull payment</dfn> or <dfn lt="payee-initiated payment|payee-initiated payments">payee-initiated payment</dfn></dt>
 
   <dd>A type of <a>transaction</a> where the <a>payee</a> initiates the
   funds transfer from the <a>payee</a>. A credit card payment is an
   example of a pull payment.</dd>
 
-  <dt><dfn>purchase</dfn></dt>
+  <dt><dfn lt="purchase|purchases">purchase</dfn></dt>
 
   <dd>Activities surrounding and including a transaction (e.g.,
   discovery of an offer, negotiation of terms, selection of payment
   instrument, delivery, etc.).</dd>
 
-  <dt><dfn>push payment</dfn> or <dfn>payer-initiated payment</dfn></dt>
+  <dt><dfn lt="push payment|push payments">push payment</dfn> or <dfn lt="payer-initiated payment|payer-initiated payments">payer-initiated payment</dfn></dt>
 
   <dd>A type of <a>transaction</a> where the <a>payer</a> initiates the
   funds transfer to the <a>payee</a>. PayPal is an example of a push
   payment.</dd>
 
-  <dt><dfn>regulator</dfn></dt>
+  <dt><dfn lt="regulator|regulators">regulator</dfn></dt>
 
   <dd>The regulator is responsible for monitoring some payments
   activities and enforcing legal requirements.</dd>
@@ -212,20 +212,20 @@ the reader:
   (who has a relationship with the Acceptor), but where the Issuer and
   the Acquirer are the same entity.</dd>
 
-  <dt><dfn>transaction</dfn></dt>
+  <dt><dfn lt="transaction|transactions">transaction</dfn></dt>
 
   <dd>An economic exchange between a <a>payer</a> and one or more
   <a title="payee">payees</a>. An agreement, communication, or movement
   carried out between a buyer and a seller to exchange an asset for
   payment</dd>
 
-  <dt><dfn>transfer order</dfn></dt>
+  <dt><dfn lt="transfer order|transfer orders">transfer order</dfn></dt>
 
   <dd>[ECB] an order or message requesting the transfer of assets (e.g.
   funds, securities, other financial instruments or commodities) from
   the debtor to the creditor</dd>
 
-  <dt><dfn>wallet</dfn></dt>
+  <dt><dfn lt="wallet|wallets">wallet</dfn></dt>
 
   <dd>
     a software service, providing similar functions in the digital world


### PR DESCRIPTION
ReSpec now supports aliases for definitions.  This will make it way easier to ensure that we are referring to terms.
