### PR TITLE
Trivial editoral edits

### DIFF
--- a/VCTF/implementers/index.html
+++ b/VCTF/implementers/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
     <meta charset="utf-8" />
-    <title>[EDITOR'S DRAFT] Implementation Commitments for Verifiable Claims Working Group</title>
+    <title>Implementation Commitments for Verifiable Claims Working Group</title>
     <link rel="stylesheet" href="//www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen"/>
     <link rel="stylesheet" type="text/css" href="//www.w3.org/Guide/pubrules-style.css"/>
     <link rel="stylesheet" type="text/css" href="//www.w3.org/2006/02/charter-style.css"/>
@@ -10,21 +10,17 @@
 
 <body>
   <p>
-      <a href="http://www.w3.org/"><img alt="W3C" height="48" src="//www.w3.org/Icons/w3c_home"
-                                                     width="72"/></a>
-      <a class="domainlogo" href="/TandS/"><img src="http://www.w3.org/Icons/tands"
-                                                alt="Technology and Society Domain"/></a>
+      <a href="http://www.w3.org/"><img alt="W3C" height="48" src="//www.w3.org/Icons/w3c_home"  width="72"/></a>
   </p>
 
-  <h1 id="title">[EDITOR'S DRAFT] Implementation Commitments for Verifiable Claims Working Group</h1>
+  <h1 id="title">Implementation Commitments for Verifiable Claims Working Group</h1>
+<p>Last substantial update 18 June 2016, editoral update 4 Nov 2016</p>
 
-  <p>
-The following organizations have committed to implementing and/or deploying
+  <p>The following organizations have committed to implementing and/or deploying
 the output of the Verifiable Claims Working Group if the work successfully
-produces a W3C standard. The implementations are broken out by roles
+produces a W3C standard (see <a href="http://w3c.github.io/webpayments-ig/VCTF/charter/">Draft charter</a>). The implementations are broken out by roles
 in the ecosystem and each organization has provided rough numbers for the
-reach of their Verifiable Claims deployments.
-  </p>
+reach of their Verifiable Claims deployments. These commitments, whilst sincere, are not binding.</p>
 
   <dl>
     <dt><strong><em>Issuers</em></strong></dt>


### PR DESCRIPTION
I just made a few minor edits to this doc ahead of the likely formal AC review of the charter. Things like removing the now redundant T&S domain logo.